### PR TITLE
Reload Safety: defensive register/unregister flow

### DIFF
--- a/RELOAD_SAFETY_FIXES.md
+++ b/RELOAD_SAFETY_FIXES.md
@@ -1,0 +1,38 @@
+# Reload Safety Fixes
+
+## Overview
+
+This change converts all operator modules from `register_classes_factory()` to a
+defensive `_safe_unregister_class` / `_get_registered_class` pattern to prevent
+errors when reloading the addon (e.g. during development or CI testing).
+
+## Problem
+
+When Blender reloads an addon (e.g. via F8 or `bpy.ops.preferences.addon_enable`),
+classes that were previously registered may still be present in `bpy.types`. Calling
+`register_classes_factory` in this situation raises a `ValueError: already registered`
+error, crashing the reload.
+
+## Solution
+
+Each operator module now defines two helper functions:
+
+- `_get_registered_class(cls)` — looks up whether a class is already registered in
+  `bpy.types` by class name or `bl_idname`.
+- `_safe_unregister_class(cls)` — silently unregisters a class, swallowing any errors.
+
+The `register()` function first clears any stale registrations, then registers each
+class fresh. The `unregister()` function always cleans up without raising errors.
+
+## Files Changed
+
+- `__init__.py` — retry-on-conflict logic in addon `register()`
+- `operators/bake_operators.py`
+- `operators/channel_operators.py`
+- `operators/group_operators.py`
+- `operators/image_operators.py`
+- `operators/layers_operators.py`
+- `operators/quick_edit.py`
+- `operators/shader_editor.py`
+- `operators/versioning_operators.py`
+- `paintsystem/data.py`

--- a/operators/bake_operators.py
+++ b/operators/bake_operators.py
@@ -1,7 +1,6 @@
 import time
 import bpy
 from bpy.types import Context, Image, Material, Operator, UILayout
-from bpy.utils import register_classes_factory
 from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty
 
 from .common import PSContextMixin, PSImageCreateMixin, DEFAULT_PS_UV_MAP_NAME
@@ -943,4 +942,42 @@ classes = (
     PAINTSYSTEM_OT_MergeUp,
 )
 
-register, unregister = register_classes_factory(classes)
+def _get_registered_class(cls):
+    class_name = getattr(cls, "__name__", None)
+    if class_name:
+        registered = getattr(bpy.types, class_name, None)
+        if registered is not None:
+            return registered
+    bl_idname = getattr(cls, "bl_idname", None)
+    if bl_idname:
+        parts = bl_idname.split(".", 1)
+        if len(parts) == 2:
+            rna_name = f"{parts[0].upper()}_OT_{parts[1]}"
+            return getattr(bpy.types, rna_name, None)
+    return None
+
+
+def _safe_unregister_class(cls):
+    if cls is None:
+        return
+    try:
+        bpy.utils.unregister_class(cls)
+    except Exception:
+        pass
+
+
+def register():
+    for cls in classes:
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError as e:
+            if "already registered" not in str(e):
+                raise
+
+def unregister():
+    for cls in reversed(classes):
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)

--- a/operators/group_operators.py
+++ b/operators/group_operators.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.props import BoolProperty, EnumProperty
 from bpy.types import Node, NodeTree, Operator
-from bpy.utils import register_classes_factory
+
 from bpy_extras.node_utils import connect_sockets, find_base_socket_type
 from mathutils import Vector
 
@@ -445,4 +445,42 @@ classes = (
     PAINTSYSTEM_OT_MoveGroup,
 )
 
-register, unregister = register_classes_factory(classes)    
+def _get_registered_class(cls):
+    class_name = getattr(cls, "__name__", None)
+    if class_name:
+        registered = getattr(bpy.types, class_name, None)
+        if registered is not None:
+            return registered
+    bl_idname = getattr(cls, "bl_idname", None)
+    if bl_idname:
+        parts = bl_idname.split(".", 1)
+        if len(parts) == 2:
+            rna_name = f"{parts[0].upper()}_OT_{parts[1]}"
+            return getattr(bpy.types, rna_name, None)
+    return None
+
+
+def _safe_unregister_class(cls):
+    if cls is None:
+        return
+    try:
+        bpy.utils.unregister_class(cls)
+    except Exception:
+        pass
+
+
+def register():
+    for cls in classes:
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError as e:
+            if "already registered" not in str(e):
+                raise
+
+def unregister():
+    for cls in reversed(classes):
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)

--- a/operators/image_operators.py
+++ b/operators/image_operators.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.types import Operator
 from bpy.props import FloatVectorProperty, StringProperty, IntProperty, EnumProperty, BoolProperty, FloatProperty
-from bpy.utils import register_classes_factory
+
 from .common import (
     PSContextMixin,
     PSImageFilterMixin,
@@ -420,4 +420,42 @@ if PIL_AVAILABLE:
     ])
 
 classes = tuple(classes)
-register, unregister = register_classes_factory(classes)
+def _get_registered_class(cls):
+    class_name = getattr(cls, "__name__", None)
+    if class_name:
+        registered = getattr(bpy.types, class_name, None)
+        if registered is not None:
+            return registered
+    bl_idname = getattr(cls, "bl_idname", None)
+    if bl_idname:
+        parts = bl_idname.split(".", 1)
+        if len(parts) == 2:
+            rna_name = f"{parts[0].upper()}_OT_{parts[1]}"
+            return getattr(bpy.types, rna_name, None)
+    return None
+
+
+def _safe_unregister_class(cls):
+    if cls is None:
+        return
+    try:
+        bpy.utils.unregister_class(cls)
+    except Exception:
+        pass
+
+
+def register():
+    for cls in classes:
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError as e:
+            if "already registered" not in str(e):
+                raise
+
+def unregister():
+    for cls in reversed(classes):
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)

--- a/operators/layers_operators.py
+++ b/operators/layers_operators.py
@@ -4,7 +4,7 @@ from bpy.props import (
     BoolProperty
 )
 from bpy.types import Operator, Context, NodeTree
-from bpy.utils import register_classes_factory
+
 import mathutils
 
 from ..paintsystem.data import (
@@ -1184,4 +1184,42 @@ classes = (
     PAINTSYSTEM_OT_NewTextureMask,
 )
 
-register, unregister = register_classes_factory(classes)
+def _get_registered_class(cls):
+    class_name = getattr(cls, "__name__", None)
+    if class_name:
+        registered = getattr(bpy.types, class_name, None)
+        if registered is not None:
+            return registered
+    bl_idname = getattr(cls, "bl_idname", None)
+    if bl_idname:
+        parts = bl_idname.split(".", 1)
+        if len(parts) == 2:
+            rna_name = f"{parts[0].upper()}_OT_{parts[1]}"
+            return getattr(bpy.types, rna_name, None)
+    return None
+
+
+def _safe_unregister_class(cls):
+    if cls is None:
+        return
+    try:
+        bpy.utils.unregister_class(cls)
+    except Exception:
+        pass
+
+
+def register():
+    for cls in classes:
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError as e:
+            if "already registered" not in str(e):
+                raise
+
+def unregister():
+    for cls in reversed(classes):
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)

--- a/operators/quick_edit.py
+++ b/operators/quick_edit.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.props import EnumProperty, StringProperty
 from bpy.types import Context, Operator
-from bpy.utils import register_classes_factory
+
 import os
 
 
@@ -579,4 +579,42 @@ classes = (
     PAINTSYSTEM_OT_ReloadImage,
 )
 
-register, unregister = register_classes_factory(classes)
+def _get_registered_class(cls):
+    class_name = getattr(cls, "__name__", None)
+    if class_name:
+        registered = getattr(bpy.types, class_name, None)
+        if registered is not None:
+            return registered
+    bl_idname = getattr(cls, "bl_idname", None)
+    if bl_idname:
+        parts = bl_idname.split(".", 1)
+        if len(parts) == 2:
+            rna_name = f"{parts[0].upper()}_OT_{parts[1]}"
+            return getattr(bpy.types, rna_name, None)
+    return None
+
+
+def _safe_unregister_class(cls):
+    if cls is None:
+        return
+    try:
+        bpy.utils.unregister_class(cls)
+    except Exception:
+        pass
+
+
+def register():
+    for cls in classes:
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError as e:
+            if "already registered" not in str(e):
+                raise
+
+def unregister():
+    for cls in reversed(classes):
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)

--- a/operators/shader_editor.py
+++ b/operators/shader_editor.py
@@ -1,6 +1,5 @@
 import bpy
 from bpy.types import Operator
-from bpy.utils import register_classes_factory
 
 from .common import PSContextMixin, execute_operator_in_area, wait_for_redraw
 from ..utils.nodes import find_node, is_in_nodetree
@@ -110,4 +109,42 @@ classes = [
     PAINTSYSTEM_OT_ExitAllNodeGroups,
 ]
 
-register, unregister = register_classes_factory(classes)
+def _get_registered_class(cls):
+    class_name = getattr(cls, "__name__", None)
+    if class_name:
+        registered = getattr(bpy.types, class_name, None)
+        if registered is not None:
+            return registered
+    bl_idname = getattr(cls, "bl_idname", None)
+    if bl_idname:
+        parts = bl_idname.split(".", 1)
+        if len(parts) == 2:
+            rna_name = f"{parts[0].upper()}_OT_{parts[1]}"
+            return getattr(bpy.types, rna_name, None)
+    return None
+
+
+def _safe_unregister_class(cls):
+    if cls is None:
+        return
+    try:
+        bpy.utils.unregister_class(cls)
+    except Exception:
+        pass
+
+
+def register():
+    for cls in classes:
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError as e:
+            if "already registered" not in str(e):
+                raise
+
+def unregister():
+    for cls in reversed(classes):
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)

--- a/operators/versioning_operators.py
+++ b/operators/versioning_operators.py
@@ -1,6 +1,5 @@
 import bpy
 from bpy.types import Operator, Object, NodeTree, Node
-from bpy.utils import register_classes_factory
 
 from ..paintsystem.version_check import get_latest_version, get_current_version, reset_version_cache
 from .common import PSContextMixin
@@ -278,4 +277,42 @@ classes = (
     PAINTSYSTEM_OT_DismissUpdate,
 )
 
-register, unregister = register_classes_factory(classes)
+def _get_registered_class(cls):
+    class_name = getattr(cls, "__name__", None)
+    if class_name:
+        registered = getattr(bpy.types, class_name, None)
+        if registered is not None:
+            return registered
+    bl_idname = getattr(cls, "bl_idname", None)
+    if bl_idname:
+        parts = bl_idname.split(".", 1)
+        if len(parts) == 2:
+            rna_name = f"{parts[0].upper()}_OT_{parts[1]}"
+            return getattr(bpy.types, rna_name, None)
+    return None
+
+
+def _safe_unregister_class(cls):
+    if cls is None:
+        return
+    try:
+        bpy.utils.unregister_class(cls)
+    except Exception:
+        pass
+
+
+def register():
+    for cls in classes:
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError as e:
+            if "already registered" not in str(e):
+                raise
+
+def unregister():
+    for cls in reversed(classes):
+        _safe_unregister_class(_get_registered_class(cls))
+        _safe_unregister_class(cls)

--- a/paintsystem/data.py
+++ b/paintsystem/data.py
@@ -3280,8 +3280,18 @@ classes = (
 _register, _unregister = register_classes_factory(classes)
 
 def register():
-    """Register the Paint System data module."""
-    _register()
+    """Register the Paint System data module with reload-safe error handling."""
+    try:
+        _register()
+    except ValueError as e:
+        if "already registered" in str(e):
+            try:
+                _unregister()
+            except Exception:
+                pass
+            _register()
+        else:
+            raise
     bpy.types.Scene.ps_scene_data = PointerProperty(
         type=PaintSystemGlobalData,
         name="Paint System Data",
@@ -3293,10 +3303,22 @@ def register():
         description="Material Data for the Paint System"
     )
     bpy.types.Material.paint_system = PointerProperty(type=LegacyPaintSystemGroups)
-    
+
 def unregister():
     """Unregister the Paint System data module."""
-    del bpy.types.Material.paint_system
-    del bpy.types.Material.ps_mat_data
-    del bpy.types.Scene.ps_scene_data
-    _unregister()
+    try:
+        del bpy.types.Material.paint_system
+    except Exception:
+        pass
+    try:
+        del bpy.types.Material.ps_mat_data
+    except Exception:
+        pass
+    try:
+        del bpy.types.Scene.ps_scene_data
+    except Exception:
+        pass
+    try:
+        _unregister()
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
Extract reload-safety changes from PinkSystem2 into a clean branch on main.

## Scope
- Defensive register/unregister patterns across operator modules
- Add reload-safety documentation

## Notes
- Related reference: #112 (superseded by this clean split)